### PR TITLE
docs: announce official encryption support and maintenance policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
 # DataStore Crypto
 
-DataStore Crypto is a Kotlin library for Android that provides encrypted [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) implementations. It is designed as a response to the Feature Request for encrypted DataStore support in DataStore (see: [Feature Request: Support for encryption in Datastore](https://issuetracker.google.com/issues/167697691)).
+> [!IMPORTANT]
+> **Official encryption support is now available in AndroidX DataStore.**
+> As of [`androidx.datastore:datastore-tink` 1.3.0-alpha07](https://developer.android.com/jetpack/androidx/releases/datastore#1.3.0-alpha07), DataStore officially supports encryption via Tink's `AeadSerializer`. For new projects, we recommend using the official artifact.
+> This library will **not** receive new features and will be maintained for the time being only. See [Official Support](#official-support) for details.
+
+DataStore Crypto is a Kotlin library for Android that provides encrypted [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) implementations. It was originally created as a response to the Feature Request for encrypted DataStore support in DataStore (see: [Feature Request: Support for encryption in Datastore](https://issuetracker.google.com/issues/167697691)), which has since been resolved by official support.
 
 It enables secure storage of key-value and typed data using DataStore, with transparent encryption and decryption of data at rest.
+
+## Official Support
+
+When this library was created, DataStore had no built-in encryption support, which was tracked in [Feature Request: Support for encryption in Datastore](https://issuetracker.google.com/issues/167697691). That request has now been addressed: starting with [`androidx.datastore:datastore-tink` 1.3.0-alpha07](https://developer.android.com/jetpack/androidx/releases/datastore#1.3.0-alpha07), DataStore officially supports encryption.
+
+The official module provides `AeadSerializer`, a `Serializer<T>` wrapper that uses [Tink](https://github.com/tink-crypto/tink-java)'s Authenticated Encryption with Associated Data (AEAD) to encrypt and decrypt data — the same cryptographic library used by DataStore Crypto. It is available on both JVM and Android platforms.
+
+For installation and usage, refer to the official [DataStore release notes](https://developer.android.com/jetpack/androidx/releases/datastore#1.3.0-alpha07).
+
+### Maintenance Policy
+
+- **No new features are planned** for this library.
+- It will continue to receive maintenance (bug fixes, dependency updates, etc.) **for the time being**.
+- New projects are encouraged to use the official `androidx.datastore:datastore-tink` artifact, and existing users are encouraged to consider migrating to it.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # DataStore Crypto
 
 > [!IMPORTANT]
-> **Official encryption support is now available in AndroidX DataStore.**
-> As of [`androidx.datastore:datastore-tink` 1.3.0-alpha07](https://developer.android.com/jetpack/androidx/releases/datastore#1.3.0-alpha07), DataStore officially supports encryption via Tink's `AeadSerializer`. For new projects, we recommend using the official artifact.
-> This library will **not** receive new features and will be maintained for the time being only. See [Official Support](#official-support) for details.
+> **Official encryption support is now available in AndroidX DataStore.** For new projects, we recommend using the official artifact. This library will not receive new features and is in maintenance mode. See [Official Support](#official-support) for details.
 
 DataStore Crypto is a Kotlin library for Android that provides encrypted [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) implementations. It was originally created as a response to the Feature Request for encrypted DataStore support in DataStore (see: [Feature Request: Support for encryption in Datastore](https://issuetracker.google.com/issues/167697691)), which has since been resolved by official support.
 


### PR DESCRIPTION
## Overview

AndroidX DataStore now provides official encryption support (the [`androidx.datastore:datastore-tink` 1.3.0-alpha07](https://developer.android.com/jetpack/androidx/releases/datastore#1.3.0-alpha07) artifact ships `AeadSerializer`). This PR updates the README to reflect that.

## Changes

- Added a prominent banner (`> [!IMPORTANT]`) announcing official support, recommending the official artifact for new projects, and stating this library's maintenance policy.
- Added a new `## Official Support` section:
  - Notes that [Issue 167697691](https://issuetracker.google.com/issues/167697691) — the request this library was built for — has been resolved by official support.
  - Summarizes the official `AeadSerializer` and links to the release notes. Concrete usage is intentionally omitted (the official API may change) and readers are pointed to the official docs.
  - **Maintenance Policy**: no new features planned, maintenance only for the time being, and migration to the official artifact is encouraged.
- Tweaked the intro paragraph to reflect that the issue has been officially resolved.
- Kept the existing Features / Usage sections intact for current users.

## Review notes

- Verify the banner renders correctly as a GitHub alert.
- Verify the `#official-support` anchor works.
- Confirm the maintenance wording ("maintained for the time being only") matches the intent.